### PR TITLE
feat: add transparent theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -12,6 +12,13 @@ export const themes = {
     text_color: "434d58",
     bg_color: "fffefe",
   },
+  transparent: {
+    title_color: "006AFF",
+    icon_color: "0579C3",
+    text_color: "417E87",
+    bg_color: "ffffff00",
+    border_color: "e4e2e2",
+  },
   dark: {
     title_color: "fff",
     icon_color: "79ff97",


### PR DESCRIPTION
Adds a transparent theme that has a contrast ratio of 4.5 on both black and white (see https://ux.stackexchange.com/a/86226).